### PR TITLE
Port ExceptT transformer

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,7 +1,7 @@
 sdk-version: 2.0.0
 name: daml-ctl
-version: 2.0.0
+version: 2.1.0
 source: daml
 dependencies:
-- daml-prim
-- daml-stdlib
+  - daml-prim
+  - daml-stdlib

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 2.0.0
+sdk-version: 2.1.1
 name: daml-ctl
 version: 2.1.0
 source: daml

--- a/daml/Daml/Control/Monad/Reader/Class.daml
+++ b/daml/Daml/Control/Monad/Reader/Class.daml
@@ -43,7 +43,7 @@ module Daml.Control.Monad.Reader.Class (
     asks,
     ) where
 
-import Daml.Control.Monad.Trans.Except (ExceptT)
+import Daml.Control.Monad.Trans.Except (ExceptT, mapExceptT)
 import Daml.Control.Monad.Trans.Reader qualified as ReaderT
 import Daml.Control.Monad.Trans.Reader (ReaderT)
 import Daml.Control.Monad.Trans.State qualified as Strict

--- a/daml/Daml/Control/Monad/Reader/Class.daml
+++ b/daml/Daml/Control/Monad/Reader/Class.daml
@@ -43,6 +43,7 @@ module Daml.Control.Monad.Reader.Class (
     asks,
     ) where
 
+import Daml.Control.Monad.Trans.Except (ExceptT)
 import Daml.Control.Monad.Trans.Reader qualified as ReaderT
 import Daml.Control.Monad.Trans.Reader (ReaderT)
 import Daml.Control.Monad.Trans.State qualified as Strict
@@ -111,6 +112,7 @@ instance (Monad m, Monoid w) => MonadReader r (StrictRWS.RWST r w s m) where
     ask = StrictRWS.ask
     local = StrictRWS.local
     reader = StrictRWS.reader
+-}
 
 -- ---------------------------------------------------------------------------
 -- Instances for other mtl transformers
@@ -118,10 +120,10 @@ instance (Monad m, Monoid w) => MonadReader r (StrictRWS.RWST r w s m) where
 -- All of these instances need UndecidableInstances,
 -- because they do not satisfy the coverage condition.
 
-instance MonadReader r' m => MonadReader r' (ContT r m) where
-    ask   = lift ask
-    local = Cont.liftLocal ask local
-    reader = lift . reader
+-- instance MonadReader r' m => MonadReader r' (ContT r m) where
+--     ask   = lift ask
+--     local = Cont.liftLocal ask local
+--     reader = lift . reader
 
 {- | @since 2.2 -}
 instance MonadReader r m => MonadReader r (ExceptT e m) where
@@ -129,6 +131,7 @@ instance MonadReader r m => MonadReader r (ExceptT e m) where
     local = mapExceptT . local
     reader = lift . reader
 
+{-
 instance MonadReader r m => MonadReader r (IdentityT m) where
     ask   = lift ask
     local = mapIdentityT . local

--- a/daml/Daml/Control/Monad/Signatures.daml
+++ b/daml/Daml/Control/Monad/Signatures.daml
@@ -1,0 +1,59 @@
+-- {-# LANGUAGE CPP #-}
+-- #if __GLASGOW_HASKELL__ >= 702
+-- {-# LANGUAGE Safe #-}
+-- #endif
+-- #if __GLASGOW_HASKELL__ >= 706
+-- {-# LANGUAGE PolyKinds #-}
+-- #endif
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Signatures
+-- Copyright   :  (c) Ross Paterson 2012
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  R.Paterson@city.ac.uk
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Signatures for monad operations that require specialized lifting.
+-- Each signature has a uniformity property that the lifting should satisfy.
+-----------------------------------------------------------------------------
+
+module Daml.Control.Monad.Signatures (
+  --   CallCC
+  -- , Catch
+    Listen
+  , Pass
+  ) where
+
+-- | Signature of the @callCC@ operation,
+-- introduced in "Control.Monad.Trans.Cont".
+-- Any lifting function @liftCallCC@ should satisfy
+--
+-- * @'Control.Monad.Trans.Class.lift' (f k) = f' ('Control.Monad.Trans.Class.lift' . k) => 'Control.Monad.Trans.Class.lift' (cf f) = liftCallCC cf f'@
+--
+-- type CallCC m a b = ((a -> m b) -> m a) -> m a
+
+-- | Signature of the @catchE@ operation,
+-- introduced in "Control.Monad.Trans.Except".
+-- Any lifting function @liftCatch@ should satisfy
+--
+-- * @'Control.Monad.Trans.Class.lift' (cf m f) = liftCatch ('Control.Monad.Trans.Class.lift' . cf) ('Control.Monad.Trans.Class.lift' f)@
+--
+-- type Catch e m a = m a -> (e -> m a) -> m a
+
+-- | Signature of the @listen@ operation,
+-- introduced in "Control.Monad.Trans.Writer".
+-- Any lifting function @liftListen@ should satisfy
+--
+-- * @'Control.Monad.Trans.Class.lift' . liftListen = liftListen . 'Control.Monad.Trans.Class.lift'@
+--
+type Listen w m a = m a -> m (a, w)
+
+-- | Signature of the @pass@ operation,
+-- introduced in "Control.Monad.Trans.Writer".
+-- Any lifting function @liftPass@ should satisfy
+--
+-- * @'Control.Monad.Trans.Class.lift' . liftPass = liftPass . 'Control.Monad.Trans.Class.lift'@
+--
+type Pass w m a =  m (a, w -> w) -> m a

--- a/daml/Daml/Control/Monad/State/Class.daml
+++ b/daml/Daml/Control/Monad/State/Class.daml
@@ -33,6 +33,7 @@ module Daml.Control.Monad.State.Class (
     gets
   ) where
 
+import Daml.Control.Monad.Trans.Except (ExceptT)
 import Daml.Control.Monad.Trans.State qualified as Strict
 import Daml.Control.Monad.Trans.Writer qualified as Strict
 -- import Daml.Control.Monad.Reader (ReaderT)
@@ -99,11 +100,11 @@ instance Monad m => MonadState s (Strict.StateT s m) where
 --
 -- All of these instances need UndecidableInstances,
 -- because they do not satisfy the coverage condition.
-{-
-instance MonadState s m => MonadState s (ContT r m) where
-    get = lift get
-    put = lift . put
-    state = lift . state
+
+-- instance MonadState s m => MonadState s (ContT r m) where
+--     get = lift get
+--     put = lift . put
+--     state = lift . state
 
 -- | @since 2.2
 instance MonadState s m => MonadState s (ExceptT e m) where
@@ -111,6 +112,7 @@ instance MonadState s m => MonadState s (ExceptT e m) where
     put = lift . put
     state = lift . state
 
+{-
 instance MonadState s m => MonadState s (IdentityT m) where
     get = lift get
     put = lift . put
@@ -126,9 +128,6 @@ instance MonadState s m => MonadState s (ReaderT r m) where
     put = lift . put
     state = lift . state
 
--}
-
-{-
 #if MIN_VERSION_transformers(0,5,6)
 -- | @since 2.3
 instance (Monoid w, MonadState s m) => MonadState s (CPS.WriterT w m) where

--- a/daml/Daml/Control/Monad/State/Class.daml
+++ b/daml/Daml/Control/Monad/State/Class.daml
@@ -36,7 +36,7 @@ module Daml.Control.Monad.State.Class (
 import Daml.Control.Monad.Trans.Except (ExceptT)
 import Daml.Control.Monad.Trans.State qualified as Strict
 import Daml.Control.Monad.Trans.Writer qualified as Strict
--- import Daml.Control.Monad.Reader (ReaderT)
+import Daml.Control.Monad.Trans.Reader (ReaderT)
 import Daml.Control.Monad.Trans.Class
 
 -- | Minimal definition is either both of @get@ and @put@ or just @state@
@@ -122,12 +122,14 @@ instance MonadState s m => MonadState s (MaybeT m) where
     get = lift get
     put = lift . put
     state = lift . state
+-}
 
 instance MonadState s m => MonadState s (ReaderT r m) where
     get = lift get
     put = lift . put
     state = lift . state
 
+{-
 #if MIN_VERSION_transformers(0,5,6)
 -- | @since 2.3
 instance (Monoid w, MonadState s m) => MonadState s (CPS.WriterT w m) where

--- a/daml/Daml/Control/Monad/Trans/Except.daml
+++ b/daml/Daml/Control/Monad/Trans/Except.daml
@@ -47,13 +47,13 @@ module Daml.Control.Monad.Trans.Except (
     finallyE,
     -- * Lifting other operations
     -- liftCallCC,
-    -- liftListen,
-    -- liftPass,
+    liftListen,
+    liftPass,
   ) where
 
 import Prelude hiding (mapA)
 -- import Control.Monad.IO.Class
--- import Control.Monad.Signatures
+import Daml.Control.Monad.Signatures (Listen, Pass)
 import Daml.Control.Monad.Trans.Class
 -- import Data.Functor.Classes
 -- #if MIN_VERSION_base(4,12,0)
@@ -338,18 +338,18 @@ finallyE m closer = do
 --     runExceptT (f (\ a -> ExceptT $ c (Right a)))
 -- {-# INLINE liftCallCC #-}
 
--- -- | Lift a @listen@ operation to the new monad.
--- liftListen : (Action m) => Listen w m (Either e a) -> Listen w (ExceptT e m) a
--- liftListen listen = mapExceptT $ \ m -> do
---     (a, w) <- listen m
---     return $! fmap (\ r -> (r, w)) a
--- {-# INLINE liftListen #-}
+-- | Lift a @listen@ operation to the new monad.
+liftListen : (Action m) => Listen w m (Either e a) -> Listen w (ExceptT e m) a
+liftListen listen = mapExceptT $ \ m -> do
+    (a, w) <- listen m
+    return $ fmap (\ r -> (r, w)) a
+{-# INLINE liftListen #-}
 
--- -- | Lift a @pass@ operation to the new monad.
--- liftPass : (Action m) => Pass w m (Either e a) -> Pass w (ExceptT e m) a
--- liftPass pass = mapExceptT $ \ m -> pass $ do
---     a <- m
---     return $! case a of
---         Left l -> (Left l, id)
---         Right (r, f) -> (Right r, f)
--- {-# INLINE liftPass #-}
+-- | Lift a @pass@ operation to the new monad.
+liftPass : (Action m) => Pass w m (Either e a) -> Pass w (ExceptT e m) a
+liftPass pass = mapExceptT $ \ m -> pass $ do
+    a <- m
+    return $ case a of
+        Left l -> (Left l, identity)
+        Right (r, f) -> (Right r, f)
+{-# INLINE liftPass #-}

--- a/daml/Daml/Control/Monad/Trans/Except.daml
+++ b/daml/Daml/Control/Monad/Trans/Except.daml
@@ -1,0 +1,356 @@
+{-# OPTIONS -Wno-deprecations #-} -- To suppress 'Monad' warnings
+-- {-# LANGUAGE CPP #-}
+-- #if __GLASGOW_HASKELL__ >= 702
+-- {-# LANGUAGE Safe #-}
+-- {-# LANGUAGE DeriveGeneric #-}
+-- #endif
+-- #if __GLASGOW_HASKELL__ >= 710 && __GLASGOW_HASKELL__ < 802
+-- {-# LANGUAGE AutoDeriveTypeable #-}
+-- #endif
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Trans.Except
+-- Copyright   :  (C) 2013 Ross Paterson
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  R.Paterson@city.ac.uk
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- This monad transformer extends a monad with the ability to throw exceptions.
+--
+-- A sequence of actions terminates normally, producing a value,
+-- only if none of the actions in the sequence throws an exception.
+-- If one throws an exception, the rest of the sequence is skipped and
+-- the composite action exits with that exception.
+--
+-- If the value of the exception is not required, the variant in
+-- "Control.Monad.Trans.Maybe" may be used instead.
+-----------------------------------------------------------------------------
+
+module Daml.Control.Monad.Trans.Except (
+    -- * The Except monad
+    Except,
+    except,
+    runExcept,
+    mapExcept,
+    withExcept,
+    -- * The ExceptT monad transformer
+    ExceptT(..),
+    runExceptT,
+    mapExceptT,
+    withExceptT,
+    -- * Exception operations
+    throwE,
+    catchE,
+    handleE,
+    tryE,
+    finallyE,
+    -- * Lifting other operations
+    -- liftCallCC,
+    -- liftListen,
+    -- liftPass,
+  ) where
+
+import Prelude hiding (mapA)
+-- import Control.Monad.IO.Class
+-- import Control.Monad.Signatures
+import Daml.Control.Monad.Trans.Class
+-- import Data.Functor.Classes
+-- #if MIN_VERSION_base(4,12,0)
+-- import Data.Functor.Contravariant
+-- #endif
+import Daml.Data.Functor.Identity
+
+-- import Control.Applicative
+-- import Control.Monad
+-- #if MIN_VERSION_base(4,9,0)
+-- import qualified Control.Monad.Fail as Fail
+-- #endif
+-- import Control.Monad.Fix
+-- #if MIN_VERSION_base(4,4,0)
+-- import Control.Monad.Zip (MonadZip(mzipWith))
+-- #endif
+-- #if !(MIN_VERSION_base(4,8,0))
+import DA.Foldable (Foldable, foldMap)
+-- import Data.Monoid (Monoid(mempty, mappend))
+import DA.Traversable (Traversable, mapA)
+-- #endif
+-- #if __GLASGOW_HASKELL__ >= 704
+-- import GHC.Generics
+-- #endif
+
+-- | The parameterizable exception monad.
+--
+-- Computations are either exceptions or normal values.
+--
+-- The 'return' function returns a normal value, while @>>=@ exits on
+-- the first exception.  For a variant that continues after an error
+-- and collects all the errors, see 'Control.Applicative.Lift.Errors'.
+type Except e = ExceptT e Identity
+
+-- | Constructor for computations in the exception monad.
+-- (The inverse of 'runExcept').
+except : (Action m) => Either e a -> ExceptT e m a
+except m = ExceptT (return m)
+{-# INLINE except #-}
+
+-- | Extractor for computations in the exception monad.
+-- (The inverse of 'except').
+runExcept : Except e a -> Either e a
+runExcept (ExceptT m) = runIdentity m
+{-# INLINE runExcept #-}
+
+-- | Map the unwrapped computation using the given function.
+--
+-- * @'runExcept' ('mapExcept' f m) = f ('runExcept' m)@
+mapExcept : (Either e a -> Either e' b)
+        -> Except e a
+        -> Except e' b
+mapExcept f = mapExceptT (Identity . f . runIdentity)
+{-# INLINE mapExcept #-}
+
+-- | Transform any exceptions thrown by the computation using the given
+-- function (a specialization of 'withExceptT').
+withExcept : (e -> e') -> Except e a -> Except e' a
+withExcept = withExceptT
+{-# INLINE withExcept #-}
+
+-- | A monad transformer that adds exceptions to other monads.
+--
+-- @ExceptT@ constructs a monad parameterized over two things:
+--
+-- * e - The exception type.
+--
+-- * m - The inner monad.
+--
+-- The 'return' function yields a computation that produces the given
+-- value, while @>>=@ sequences two subcomputations, exiting on the
+-- first exception.
+newtype ExceptT e m a = ExceptT (m (Either e a))
+-- #if __GLASGOW_HASKELL__ >= 710
+--     deriving (Generic, Generic1)
+-- #elif __GLASGOW_HASKELL__ >= 704
+--     deriving (Generic)
+-- #endif
+
+-- instance (Eq e, Eq1 m) => Eq1 (ExceptT e m) where
+--     liftEq eq (ExceptT x) (ExceptT y) = liftEq (liftEq eq) x y
+--     {-# INLINE liftEq #-}
+
+-- instance (Ord e, Ord1 m) => Ord1 (ExceptT e m) where
+--     liftCompare comp (ExceptT x) (ExceptT y) =
+--         liftCompare (liftCompare comp) x y
+--     {-# INLINE liftCompare #-}
+
+-- instance (Read e, Read1 m) => Read1 (ExceptT e m) where
+--     liftReadsPrec rp rl = readsData $
+--         readsUnaryWith (liftReadsPrec rp' rl') "ExceptT" ExceptT
+--       where
+--         rp' = liftReadsPrec rp rl
+--         rl' = liftReadList rp rl
+
+-- instance (Show e, Show1 m) => Show1 (ExceptT e m) where
+--     liftShowsPrec sp sl d (ExceptT m) =
+--         showsUnaryWith (liftShowsPrec sp' sl') "ExceptT" d m
+--       where
+--         sp' = liftShowsPrec sp sl
+--         sl' = liftShowList sp sl
+
+-- instance (Eq e, Eq1 m, Eq a) => Eq (ExceptT e m a)
+--     where (==) = eq1
+-- instance (Ord e, Ord1 m, Ord a) => Ord (ExceptT e m a)
+--     where compare = compare1
+-- instance (Read e, Read1 m, Read a) => Read (ExceptT e m a) where
+--     readsPrec = readsPrec1
+-- instance (Show e, Show1 m, Show a) => Show (ExceptT e m a) where
+--     showsPrec = showsPrec1
+
+-- | The inverse of 'ExceptT'.
+runExceptT : ExceptT e m a -> m (Either e a)
+runExceptT (ExceptT m) = m
+{-# INLINE runExceptT #-}
+
+-- | Map the unwrapped computation using the given function.
+--
+-- * @'runExceptT' ('mapExceptT' f m) = f ('runExceptT' m)@
+mapExceptT : (m (Either e a) -> n (Either e' b))
+        -> ExceptT e m a
+        -> ExceptT e' n b
+mapExceptT f m = ExceptT $ f (runExceptT m)
+{-# INLINE mapExceptT #-}
+
+-- | Transform any exceptions thrown by the computation using the
+-- given function.
+withExceptT : (Functor m) => (e -> e') -> ExceptT e m a -> ExceptT e' m a
+withExceptT f = mapExceptT $ fmap $ either (Left . f) Right
+{-# INLINE withExceptT #-}
+
+instance (Functor m) => Functor (ExceptT e m) where
+    fmap f = ExceptT . fmap (fmap f) . runExceptT
+    {-# INLINE fmap #-}
+
+instance (Foldable f) => Foldable (ExceptT e f) where
+    foldMap f (ExceptT a) = foldMap (either (const mempty) f) a
+    {-# INLINE foldMap #-}
+
+instance (Traversable f) => Traversable (ExceptT e f) where
+    mapA f (ExceptT a) =
+        ExceptT <$> mapA (either (pure . Left) (fmap Right . f)) a
+    {-# INLINE mapA #-}
+
+instance (Functor m, Action m) => Applicative (ExceptT e m) where
+    pure a = ExceptT $ return (Right a)
+    {-# INLINE pure #-}
+    ExceptT f <*> ExceptT v = ExceptT $ do
+        mf <- f
+        case mf of
+            Left e -> return (Left e)
+            Right k -> do
+                mv <- v
+                case mv of
+                    Left e -> return (Left e)
+                    Right x -> return (Right (k x))
+    {-# INLINEABLE (<*>) #-}
+    m *> k = m >>= \_ -> k
+    {-# INLINE (*>) #-}
+
+-- instance (Functor m, Action m, Monoid e) => Alternative (ExceptT e m) where
+--     empty = ExceptT $ return (Left mempty)
+--     {-# INLINE empty #-}
+--     ExceptT mx <|> ExceptT my = ExceptT $ do
+--         ex <- mx
+--         case ex of
+--             Left e -> liftM (either (Left . mappend e) Right) my
+--             Right x -> return (Right x)
+--     {-# INLINEABLE (<|>) #-}
+
+instance (Action m) => Action (ExceptT e m) where
+-- #if !(MIN_VERSION_base(4,8,0))
+--     return a = ExceptT $ return (Right a)
+--     {-# INLINE return #-}
+-- #endif
+    m >>= k = ExceptT $ do
+        a <- runExceptT m
+        case a of
+            Left e -> return (Left e)
+            Right x -> runExceptT (k x)
+    {-# INLINE (>>=) #-}
+-- #if !(MIN_VERSION_base(4,13,0))
+--     fail = ExceptT . fail
+--     {-# INLINE fail #-}
+-- #endif
+
+-- #if MIN_VERSION_base(4,9,0)
+-- instance (Fail.MonadFail m) => Fail.MonadFail (ExceptT e m) where
+--     fail = ExceptT . Fail.fail
+--     {-# INLINE fail #-}
+-- #endif
+
+-- instance (Action m, Monoid e) => MonadPlus (ExceptT e m) where
+--     mzero = ExceptT $ return (Left mempty)
+--     {-# INLINE mzero #-}
+    -- ExceptT mx `mplus` ExceptT my = ExceptT $ do
+    --     ex <- mx
+    --     case ex of
+    --         Left e -> liftM (either (Left . mappend e) Right) my
+    --         Right x -> return (Right x)
+    -- {-# INLINEABLE mplus #-}
+
+-- instance (MonadFix m) => MonadFix (ExceptT e m) where
+--     mfix f = ExceptT (mfix (runExceptT . f . either (const bomb) id))
+--       where bomb = error "mfix (ExceptT): inner computation returned Left value"
+--     {-# INLINE mfix #-}
+
+instance MonadTrans (ExceptT e) where
+    -- lift = ExceptT . liftM Right
+    lift mx = ExceptT $ Right <$> mx
+    {-# INLINE lift #-}
+
+-- instance (MonadIO m) => MonadIO (ExceptT e m) where
+--     liftIO = lift . liftIO
+--     {-# INLINE liftIO #-}
+
+-- #if MIN_VERSION_base(4,4,0)
+-- instance (MonadZip m) => MonadZip (ExceptT e m) where
+--     mzipWith f (ExceptT a) (ExceptT b) = ExceptT $ mzipWith (liftA2 f) a b
+--     {-# INLINE mzipWith #-}
+-- #endif
+
+-- #if MIN_VERSION_base(4,12,0)
+-- instance Contravariant m => Contravariant (ExceptT e m) where
+--     contramap f = ExceptT . contramap (fmap f) . runExceptT
+--     {-# INLINE contramap #-}
+-- #endif
+
+-- | Signal an exception value @e@.
+--
+-- * @'runExceptT' ('throwE' e) = 'return' ('Left' e)@
+--
+-- * @'throwE' e >>= m = 'throwE' e@
+throwE : (Action m) => e -> ExceptT e m a
+throwE = ExceptT . return . Left
+{-# INLINE throwE #-}
+
+-- | Handle an exception.
+--
+-- * @'catchE' ('lift' m) h = 'lift' m@
+--
+-- * @'catchE' ('throwE' e) h = h e@
+catchE : (Action m) =>
+    ExceptT e m a               -- ^ the inner computation
+    -> (e -> ExceptT e' m a)    -- ^ a handler for exceptions in the inner
+                                -- computation
+    -> ExceptT e' m a
+m `catchE` h = ExceptT $ do
+    a <- runExceptT m
+    case a of
+        Left  l -> runExceptT (h l)
+        Right r -> return (Right r)
+{-# INLINE catchE #-}
+
+-- | The same as @'flip' 'catchE'@, which is useful in situations where
+-- the code for the handler is shorter.
+handleE : Action m => (e -> ExceptT e' m a) -> ExceptT e m a -> ExceptT e' m a
+handleE = flip catchE
+{-# INLINE handleE #-}
+
+-- | Similar to 'catchE', but returns an 'Either' result which is
+-- @('Right' a)@ if no exception was thown, or @('Left' ex)@ if an
+-- exception @ex@ was thrown.
+tryE : Action m => ExceptT e m a -> ExceptT e m (Either e a)
+tryE m = catchE (Right <$> m) (return . Left)
+{-# INLINE tryE #-}
+
+-- | @'finallyE' a b@ executes computation @a@ followed by computation @b@,
+-- even if @a@ exits early by throwing an exception.  In the latter case,
+-- the exception is re-thrown after @b@ has been executed.
+finallyE : Action m => ExceptT e m a -> ExceptT e m () -> ExceptT e m a
+finallyE m closer = do
+    res <- tryE m
+    closer
+    either throwE return res
+{-# INLINE finallyE #-}
+
+-- -- | Lift a @callCC@ operation to the new monad.
+-- liftCallCC : CallCC m (Either e a) (Either e b) -> CallCC (ExceptT e m) a b
+-- liftCallCC callCC f = ExceptT $
+--     callCC $ \ c ->
+--     runExceptT (f (\ a -> ExceptT $ c (Right a)))
+-- {-# INLINE liftCallCC #-}
+
+-- -- | Lift a @listen@ operation to the new monad.
+-- liftListen : (Action m) => Listen w m (Either e a) -> Listen w (ExceptT e m) a
+-- liftListen listen = mapExceptT $ \ m -> do
+--     (a, w) <- listen m
+--     return $! fmap (\ r -> (r, w)) a
+-- {-# INLINE liftListen #-}
+
+-- -- | Lift a @pass@ operation to the new monad.
+-- liftPass : (Action m) => Pass w m (Either e a) -> Pass w (ExceptT e m) a
+-- liftPass pass = mapExceptT $ \ m -> pass $ do
+--     a <- m
+--     return $! case a of
+--         Left l -> (Left l, id)
+--         Right (r, f) -> (Right r, f)
+-- {-# INLINE liftPass #-}

--- a/daml/Daml/Control/Monad/Trans/Except.daml
+++ b/daml/Daml/Control/Monad/Trans/Except.daml
@@ -1,4 +1,3 @@
-{-# OPTIONS -Wno-deprecations #-} -- To suppress 'Monad' warnings
 -- {-# LANGUAGE CPP #-}
 -- #if __GLASGOW_HASKELL__ >= 702
 -- {-# LANGUAGE Safe #-}

--- a/daml/Daml/Control/Monad/Writer/Class.daml
+++ b/daml/Daml/Control/Monad/Writer/Class.daml
@@ -25,6 +25,7 @@ module Daml.Control.Monad.Writer.Class (
     censor,
   ) where
 
+import Daml.Control.Monad.Trans.Except qualified as Except
 import Daml.Control.Monad.Trans.Writer qualified as Strict
 import Daml.Control.Monad.Trans.State qualified as Strict
 import Daml.Control.Monad.Trans.Reader (ReaderT, mapReaderT)
@@ -130,6 +131,7 @@ instance (Monoid w, Monad m) => MonadWriter w (StrictRWS.RWST r w s m) where
     tell   = StrictRWS.tell
     listen = StrictRWS.listen
     pass   = StrictRWS.pass
+-}
 
 -- ---------------------------------------------------------------------------
 -- Instances for other mtl transformers
@@ -138,12 +140,13 @@ instance (Monoid w, Monad m) => MonadWriter w (StrictRWS.RWST r w s m) where
 -- because they do not satisfy the coverage condition.
 
 -- | @since 2.2
-instance MonadWriter w m => MonadWriter w (ExceptT e m) where
+instance MonadWriter w m => MonadWriter w (Except.ExceptT e m) where
     writer = lift . writer
     tell   = lift . tell
     listen = Except.liftListen listen
     pass   = Except.liftPass pass
 
+{-
 instance MonadWriter w m => MonadWriter w (IdentityT m) where
     writer = lift . writer
     tell   = lift . tell


### PR DESCRIPTION
I stuck to the existing convention of taking the original file and commenting out incompatible / not needed pieces.

I believe I just had to replace instances of liftM with <$>.

I am bumping the version to 2.1.0 as this change adds a new feature.