### PR TITLE
Add `Foldable` and `Traversable` instances for`ListF`

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 2.1.1
+sdk-version: 2.4.0
 name: daml-ctl
 version: 2.2.1
 source: daml

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,6 +1,6 @@
 sdk-version: 2.1.1
 name: daml-ctl
-version: 2.1.1
+version: 2.2.1
 source: daml
 dependencies:
   - daml-prim

--- a/daml/Daml/Control/Recursion.daml
+++ b/daml/Daml/Control/Recursion.daml
@@ -1,6 +1,6 @@
 {-# OPTIONS -Wno-deprecations #-} -- To supress 'Monad' warnings
 {-
-This module is adapted from Haskell's recursion-schemes. I've included the 
+This module is adapted from Haskell's recursion-schemes. I've included the
 copyright to give credit where it's due.
 
 This module differs from it in these ways:
@@ -47,13 +47,14 @@ module Daml.Control.Recursion (
 ) where
 
 import DA.Foldable (Foldable(..))
-import DA.Traversable (Traversable(..))
+import DA.Traversable (Traversable(..), mapA)
 import Daml.Control.Category ((>>>),(<<<))
 import Daml.Control.Arrow ((&&&),(|||))
 import Daml.Control.Comonad
 import Daml.Control.Monad.Trans.Free (FreeF, FreeT(..), runFreeT)
 import Daml.Control.Monad.Trans.Free qualified as F (FreeF(..))
 import Daml.Data.Functor.Identity
+import Prelude hiding (mapA)
 
 class Functor f => Recursive b f | b -> f b where
   project: b -> f b
@@ -74,6 +75,10 @@ class Functor f => Recursive b f | b -> f b where
   -- Note in Daml we can't use `Update`, as it's not a `Comonad`.
   gcata : Comonad w => (forall z . f (w z) -> w (f z)) -> (f (w a) -> a) -> b -> a
   gcata sequence f b = (_gcata sequence f >>> extract >>> f) b
+
+-- | Monadic catamorphism.
+cataM : (Monad m, Traversable f, Recursive b f) => (f a -> m a) -> b -> m a
+cataM f b = (project >>> mapA (cataM f) >>> (>>= f)) b
 
 distCata : Functor f => f (Identity a) -> Identity (f a)
 distCata = Identity . fmap runIdentity

--- a/daml/Daml/Control/Recursion.daml
+++ b/daml/Daml/Control/Recursion.daml
@@ -46,6 +46,8 @@ module Daml.Control.Recursion (
   , distFutu
 ) where
 
+import DA.Foldable (Foldable(..))
+import DA.Traversable (Traversable(..))
 import Daml.Control.Category ((>>>),(<<<))
 import Daml.Control.Arrow ((&&&),(|||))
 import Daml.Control.Comonad
@@ -169,6 +171,14 @@ instance Recursive [a] (ListF a) where
 instance Corecursive [a] (ListF a) where
   embed Nil = []
   embed (Cons a as) = a :: as
+
+instance Foldable (ListF a) where
+  foldMap _ Nil = mempty
+  foldMap f (Cons _ x) = f x
+
+instance Traversable (ListF a) where
+  mapA _ Nil = pure Nil
+  mapA f (Cons a b) = Cons a <$> f b
 
 newtype Fix f = Fix { unfix : f (Fix f) }
 


### PR DESCRIPTION
This is needed in order to use `ListF` with `cataM`.

I also think that `cataM` and similar functions belong to `daml-ctl`, but understand why they have been kept separate