### PR TITLE
change build-options to target=1.15

### DIFF
--- a/daml.yaml
+++ b/daml.yaml
@@ -1,7 +1,9 @@
 sdk-version: 2.4.0
 name: daml-ctl
-version: 2.2.2
+version: 2.2.3
 source: daml
 dependencies:
   - daml-prim
   - daml-stdlib
+build-options:
+  - --target=1.15

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,6 +1,6 @@
 sdk-version: 2.4.0
 name: daml-ctl
-version: 2.2.3
+version: 2.3.0
 source: daml
 dependencies:
   - daml-prim


### PR DESCRIPTION
I have aligned build-options with Daml Finance to target=1.15 (required for java codegen to work).