### PR TITLE
Pre-release version for Daml-3 (LF-2).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 executors:
   daml-docker-executor:
     docker:
-      - image: cimg/base:2022.10
+      - image: cimg/openjdk:11.0
 
 commands:
   install_sdk:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 executors:
   daml-docker-executor:
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/base:2022.10
 
 commands:
   install_sdk:

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,9 +1,7 @@
-sdk-version: 2.5.3
+sdk-version: 3.0.0-snapshot.20240221.0
 name: daml-ctl
-version: 2.4.0
+version: 4.99.0.20240226.1
 source: daml
 dependencies:
   - daml-prim
   - daml-stdlib
-build-options:
-  - --target=1.15


### PR DESCRIPTION
We expect this to eventually become version 5.0.0 without changes.
The version number has been chosen for parity with daml-finance, where the change to LF-2 is also being done in 5.x versions. Note that canton 3.x nodes are not backward compatible with LF-1.