### PR TITLE
Release daml-ctl-2.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,5 @@
-#
-# Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-#
+# Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 
 version: 2.1
 
@@ -129,7 +127,7 @@ workflows:
               only:
                 - master
       - release:
-          context: 
+          context:
             - github-fin-eng-context
             - npn-publish
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 # Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: Apache-2.0
 
 version: 2.1
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
-BSD 3-Clause License
+# License
 
 Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
-SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -33,16 +33,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 This library (libraries/base) is derived from code from several
 sources:
 
-  * Code from the GHC project which is largely (c) The University of
-    Glasgow, and distributable under a BSD-style license (see below),
+* Code from the GHC project which is largely (c) The University of
+  Glasgow, and distributable under a BSD-style license (see below),
 
-  * Code from the Haskell 98 Report which is (c) Simon Peyton Jones
-    and freely redistributable (but see the full license for
-    restrictions).
+* Code from the Haskell 98 Report which is (c) Simon Peyton Jones
+  and freely redistributable (but see the full license for
+  restrictions).
 
-  * Code from the Haskell Foreign Function Interface specification,
-    which is (c) Manuel M. T. Chakravarty and freely redistributable
-    (but see the full license for restrictions).
+* Code from the Haskell Foreign Function Interface specification,
+  which is (c) Manuel M. T. Chakravarty and freely redistributable
+  (but see the full license for restrictions).
 
 The full text of these licenses is reproduced below.  All of the
 licenses are BSD-style or compatible.
@@ -57,16 +57,16 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
 
-- Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-- Neither name of the University nor the names of its contributors may be
-used to endorse or promote products derived from this software without
-specific prior written permission.
+* Neither name of the University nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY COURT OF THE UNIVERSITY OF
 GLASGOW AND THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 BSD 3-Clause License
 
-Copyright (c) 2021, Digital Asset (Switzerland) GmbH
-All rights reserved.
+Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -----------------------------------------------------------------------------
 
 This library (libraries/base) is derived from code from several
-sources: 
+sources:
 
   * Code from the GHC project which is largely (c) The University of
     Glasgow, and distributable under a BSD-style license (see below),
@@ -51,7 +51,7 @@ licenses are BSD-style or compatible.
 
 The Glasgow Haskell Compiler License
 
-Copyright 2004, The University Court of the University of Glasgow. 
+Copyright 2004, The University Court of the University of Glasgow.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -59,14 +59,14 @@ modification, are permitted provided that the following conditions are met:
 
 - Redistributions of source code must retain the above copyright notice,
 this list of conditions and the following disclaimer.
- 
+
 - Redistributions in binary form must reproduce the above copyright notice,
 this list of conditions and the following disclaimer in the documentation
 and/or other materials provided with the distribution.
- 
+
 - Neither name of the University nor the names of its contributors may be
 used to endorse or promote products derived from this software without
-specific prior written permission. 
+specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY COURT OF THE UNIVERSITY OF
 GLASGOW AND THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # CTL Library
 
 This is a temporary library for collecting flow-of-control (think Haskell's `Control` modules) code.
-The plan is to eventually split this up into separate libraries. Currently, among other things, this includes:
+The plan is to eventually split this up into separate libraries. Currently, among other things, this
+includes:
 
 * Contravariant
 * Arrow
 * Monad Transformers (Reader, Writer, State)
 * Recursion Schemes
 
-**Expect breaking changes**
+**Expect breaking changes.**
 
-# License & Acknowledgements
+## License & Acknowledgements
 
-Licensed under multiple terms (mainly BSD and GHC - see LICENSE file and individual source file headers), as most of this code is transliterated into Daml from Haskell standard libraries.
+Licensed under multiple terms (mainly BSD and GHC - see LICENSE file and individual source file
+headers), as most of this code is transliterated into Daml from Haskell standard libraries.

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,6 +1,6 @@
-sdk-version: 3.0.0-snapshot.20240221.0
+sdk-version: 2.9.1
 name: daml-ctl
-version: 4.99.0.20240226.1
+version: 2.4.1
 source: daml
 dependencies:
   - daml-prim

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,4 +1,4 @@
-sdk-version: 2.9.1
+sdk-version: 2.9.3
 name: daml-ctl
 version: 2.4.1
 source: daml

--- a/daml/Daml/Control/Arrow/CoKleisli.daml
+++ b/daml/Daml/Control/Arrow/CoKleisli.daml
@@ -9,7 +9,7 @@
 -- Portability  : portable
 --
 -------------------------------------------------------------------------------------------
-module Daml.Control.Arrow.CoKleisli 
+module Daml.Control.Arrow.CoKleisli
   ( CoKleisli(..)
   ) where
 

--- a/daml/Daml/Control/Comonad.daml
+++ b/daml/Daml/Control/Comonad.daml
@@ -1,7 +1,5 @@
---
--- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: BSD-3-Clause
---
 
 module Daml.Control.Comonad where
 

--- a/daml/Daml/Control/Comonad.daml
+++ b/daml/Daml/Control/Comonad.daml
@@ -1,5 +1,5 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: BSD-3-Clause
+-- SPDX-License-Identifier: Apache-2.0
 
 module Daml.Control.Comonad where
 

--- a/daml/Daml/Control/Monad/Trans/Free.daml
+++ b/daml/Daml/Control/Monad/Trans/Free.daml
@@ -383,7 +383,7 @@ instance (Functor f, MonadWriter w m) => MonadWriter w (FreeT f m) where
 -- #endif
 
 -- Recursive helper fns for MonadWriter Instance
-pass' : (Functor f, MonadWriter w m) => m (FreeF f ((a, w -> w), w) (FreeT f m ((a, w -> w), w))) -> m (FreeF f a (FreeT f m a)) 
+pass' : (Functor f, MonadWriter w m) => m (FreeF f ((a, w -> w), w) (FreeT f m ((a, w -> w), w))) -> m (FreeF f a (FreeT f m a))
 pass' = join . liftM g
 g (Pure ((x, f), w)) = tell (f w) >> return (Pure x)
 g (Free f)           = return . Free . fmap (FreeT . pass' . runFreeT) $ f

--- a/daml/Daml/Control/Monad/Trans/Writer.daml
+++ b/daml/Daml/Control/Monad/Trans/Writer.daml
@@ -61,7 +61,7 @@ import Daml.Control.Monad.Trans.Class
 -- mport Data.Functor.Contravariant
 -- endif
 import Daml.Data.Functor.Identity
--- 
+--
 -- mport Control.Applicative
 -- mport Control.Monad
 -- if MIN_VERSION_base(4,9,0)

--- a/daml/Daml/Data/Functor/Const.daml
+++ b/daml/Daml/Data/Functor/Const.daml
@@ -1,5 +1,5 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: Apache-2.0
+-- SPDX-License-Identifier: BSD-3-Clause
 
 module Daml.Data.Functor.Const where
 

--- a/daml/Daml/Data/Functor/Const.daml
+++ b/daml/Daml/Data/Functor/Const.daml
@@ -1,7 +1,5 @@
---
--- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: BSD-3-Clause
---
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module Daml.Data.Functor.Const where
 

--- a/daml/Daml/Data/Functor/Const.daml
+++ b/daml/Daml/Data/Functor/Const.daml
@@ -1,5 +1,5 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: BSD-3-Clause
+-- SPDX-License-Identifier: Apache-2.0
 
 module Daml.Data.Functor.Const where
 

--- a/daml/Daml/Data/Functor/Identity.daml
+++ b/daml/Daml/Data/Functor/Identity.daml
@@ -1,5 +1,5 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: BSD-3-Clause
+-- SPDX-License-Identifier: Apache-2.0
 
 module Daml.Data.Functor.Identity where
 

--- a/daml/Daml/Data/Functor/Identity.daml
+++ b/daml/Daml/Data/Functor/Identity.daml
@@ -1,7 +1,5 @@
---
--- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: BSD-3-Clause
---
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module Daml.Data.Functor.Identity where
 

--- a/daml/Daml/Data/Functor/Identity.daml
+++ b/daml/Daml/Data/Functor/Identity.daml
@@ -1,5 +1,5 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: Apache-2.0
+-- SPDX-License-Identifier: BSD-3-Clause
 
 module Daml.Data.Functor.Identity where
 

--- a/daml/Daml/Data/IOr.daml
+++ b/daml/Daml/Data/IOr.daml
@@ -1,10 +1,10 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: Apache-2.0
+-- SPDX-License-Identifier: BSD-3-Clause
 
 module Daml.Data.IOr where
 
-import Prelude hiding (Left, Right)
 import DA.Bifunctor
+import Prelude hiding (Left, Right)
 
 data IOr a b
   = Left a

--- a/daml/Daml/Data/IOr.daml
+++ b/daml/Daml/Data/IOr.daml
@@ -1,7 +1,5 @@
---
--- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: BSD-3-Clause
---
+-- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
 
 module Daml.Data.IOr where
 

--- a/daml/Daml/Data/IOr.daml
+++ b/daml/Daml/Data/IOr.daml
@@ -1,5 +1,5 @@
 -- Copyright (c) 2024 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
--- SPDX-License-Identifier: BSD-3-Clause
+-- SPDX-License-Identifier: Apache-2.0
 
 module Daml.Data.IOr where
 

--- a/docs/RELEASE.MD
+++ b/docs/RELEASE.MD
@@ -6,15 +6,18 @@ The purpose of this document is to describe the procedure to release this librar
 
 1. Create a new local Git branch.
 2. In [daml.yaml](../daml.yaml), update the `version` value as required :
-   - To check what `versions` already exist, check the existing tags [here](https://github.com/digital-asset/daml-ctl/tags).
-   - Note - do not add a `v` in front of the `version` in [daml.yaml](../daml.yaml). The build script handles the naming conventions of the release, the tag and the release artifacts.
+   - To check what `versions` already exist, check the existing tags
+     [here](https://github.com/digital-asset/daml-ctl/tags).
+   - Note - do not add a `v` in front of the `version` in [daml.yaml](../daml.yaml). The build
+     script handles the naming conventions of the release, the tag and the release artifacts.
 3. Run `daml build` :
    - This command validates the specified `version`;
    - A successful build means the `version` specified is valid.
 4. Push your branch to GitHub.
 5. Create a pull request to merge your branch to `master`.
 6. Get approval and merge this branch.
-7. When the branch gets merged to `master`, a CI job gets triggered which will build the project and then perform the release:
+7. When the branch gets merged to `master`, a CI job gets triggered which will build the project and
+   then perform the release:
    - If building the project fails, the release step will not get triggered;
    - If the build is successful then :
      - If the `version` already exists, the release will fail;
@@ -28,7 +31,7 @@ The purpose of this document is to describe the procedure to release this librar
 
 This project will follow Semantic Versioning :
 
-```
+```{}
 Given a version number `MAJOR.MINOR.PATCH`, increment the:
 
 1. MAJOR version when you make incompatible API changes,
@@ -38,25 +41,26 @@ Given a version number `MAJOR.MINOR.PATCH`, increment the:
 
 See [here](https://semver.org/) for further information.
 
-
 ### Pre-release versioning
 
-Due to the underying Haskell tooling which Daml is built upon, versioning is limited to the following regex:
+Due to the underying Haskell tooling which Daml is built upon, versioning is limited to the
+following regex:
 
-```
+```{}
 ^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*$
 ```
 
 For pre-release versioning we cannot use `-ALPHA`, `-SNAPSHOT`, `-RC1`, etc. For example:
 
-```
+```{}
 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
 ```
 
 To overcome this limitation, we will use dates to represent pre-release canditates. For example:
 
-```
+```{}
 1.0.0.20220627.1 < 1.0.0.20220627.2 < 1.0.0.20220628.1 < 1.0.0
 ```
 
-Therefore, any release version specified outside of the Official release versioning will be marked as 'Pre-Release' in GitHub (for example, any version outside of `MAJOR.MINOR.PATCH`).
+Therefore, any release version specified outside of the Official release versioning will be marked
+as 'Pre-Release' in GitHub (for example, any version outside of `MAJOR.MINOR.PATCH`).


### PR DESCRIPTION
This PR is for releasing **daml-ctl-2.4.1**:
1. bumps the minor version of daml-ctl to 2.4.1 => triggers a new release (when merged to main)
2. updates the SDK to 2.9.3
3. update copy right headers
4. some minor style changes
5. change license from **BSD 3-Clause** to **APACHE 2.0** (was confirmed by legal)

**TODO:** 
- [x] Rebuild once 2.9.3 is released. Probably worth making a patch release due to point 5 alone, we can also consider letting DF depend on the new version in `main`.